### PR TITLE
fix: remove outputSchema to fix MCP SDK 1.27+ compatibility

### DIFF
--- a/src/tools/accountTools.ts
+++ b/src/tools/accountTools.ts
@@ -364,7 +364,6 @@ Errors:
   - "No default budget set" → run ynab_set_default_budget first
   - "UNAUTHORIZED" → YNAB token expired`,
 		inputSchema: ListAccountsSchema,
-		outputSchema: ListAccountsOutputSchema,
 		handler: adaptWithDelta(handleListAccounts),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof ListAccountsSchema>>(),
@@ -391,7 +390,6 @@ Errors:
   - "No default budget set" → run ynab_set_default_budget first
   - "Account not found" → invalid account_id`,
 		inputSchema: GetAccountSchema,
-		outputSchema: GetAccountOutputSchema,
 		handler: adapt(handleGetAccount),
 		defaultArgumentResolver: budgetResolver<z.infer<typeof GetAccountSchema>>(),
 		metadata: {
@@ -419,7 +417,6 @@ Examples:
   - Create checking account: set name="My Checking", type="checking"
   - Dry run: set dry_run=true to preview without saving`,
 		inputSchema: CreateAccountSchema,
-		outputSchema: CreateAccountOutputSchema,
 		handler: adaptWrite(handleCreateAccount),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof CreateAccountSchema>>(),

--- a/src/tools/budgetTools.ts
+++ b/src/tools/budgetTools.ts
@@ -179,7 +179,6 @@ Examples:
 Errors:
   - "UNAUTHORIZED" → YNAB token expired or invalid`,
 		inputSchema: ListBudgetsSchema,
-		outputSchema: ListBudgetsOutputSchema,
 		handler: adaptWithDelta(handleListBudgets),
 		metadata: {
 			annotations: {
@@ -205,7 +204,6 @@ Examples:
 Errors:
   - "Budget not found" → invalid or inaccessible budget_id`,
 		inputSchema: GetBudgetSchema,
-		outputSchema: GetBudgetOutputSchema,
 		handler: adapt(handleGetBudget),
 		metadata: {
 			annotations: {

--- a/src/tools/categoryTools.ts
+++ b/src/tools/categoryTools.ts
@@ -426,7 +426,6 @@ Examples:
 Errors:
   - "No default budget set" → run ynab_set_default_budget first`,
 		inputSchema: ListCategoriesSchema,
-		outputSchema: ListCategoriesOutputSchema,
 		handler: adaptWithDelta(handleListCategories),
 		defaultArgumentResolver: budgetResolver<ListCategoriesParams>(),
 		metadata: {
@@ -452,7 +451,6 @@ Errors:
   - "No default budget set" → run ynab_set_default_budget first
   - "Category not found" → invalid category_id`,
 		inputSchema: GetCategorySchema,
-		outputSchema: GetCategoryOutputSchema,
 		handler: adapt(handleGetCategory),
 		defaultArgumentResolver: budgetResolver<GetCategoryParams>(),
 		metadata: {
@@ -482,7 +480,6 @@ Examples:
 Errors:
   - "No default budget set" → run ynab_set_default_budget first`,
 		inputSchema: UpdateCategorySchema,
-		outputSchema: UpdateCategoryOutputSchema,
 		handler: adaptWrite(handleUpdateCategory),
 		defaultArgumentResolver: budgetResolver<UpdateCategoryParams>(),
 		metadata: {

--- a/src/tools/monthTools.ts
+++ b/src/tools/monthTools.ts
@@ -249,7 +249,6 @@ Examples:
 Errors:
   - "No default budget set" → run ynab_set_default_budget first`,
 		inputSchema: GetMonthSchema,
-		outputSchema: GetMonthOutputSchema,
 		handler: adapt(handleGetMonth),
 		defaultArgumentResolver: budgetResolver<z.infer<typeof GetMonthSchema>>(),
 		metadata: {
@@ -279,7 +278,6 @@ Examples:
 Errors:
   - "No default budget set" → run ynab_set_default_budget first`,
 		inputSchema: ListMonthsSchema,
-		outputSchema: ListMonthsOutputSchema,
 		handler: adaptWithDelta(handleListMonths),
 		defaultArgumentResolver: budgetResolver<z.infer<typeof ListMonthsSchema>>(),
 		metadata: {

--- a/src/tools/payeeTools.ts
+++ b/src/tools/payeeTools.ts
@@ -216,7 +216,6 @@ Examples:
 Errors:
   - "No default budget set" → run ynab_set_default_budget first`,
 		inputSchema: ListPayeesSchema,
-		outputSchema: ListPayeesOutputSchema,
 		handler: adaptWithDelta(handleListPayees),
 		defaultArgumentResolver: budgetResolver<z.infer<typeof ListPayeesSchema>>(),
 		metadata: {
@@ -242,7 +241,6 @@ Errors:
   - "No default budget set" → run ynab_set_default_budget first
   - "Payee not found" → invalid payee_id`,
 		inputSchema: GetPayeeSchema,
-		outputSchema: GetPayeeOutputSchema,
 		handler: adapt(handleGetPayee),
 		defaultArgumentResolver: budgetResolver<z.infer<typeof GetPayeeSchema>>(),
 		metadata: {

--- a/src/tools/transactionReadTools.ts
+++ b/src/tools/transactionReadTools.ts
@@ -344,7 +344,6 @@ Errors:
   - "No default budget set" → run ynab_set_default_budget first
   - Large result → use ynab_export_transactions to save to file`,
 		inputSchema: ListTransactionsSchema,
-		outputSchema: ListTransactionsOutputSchema,
 		handler: adaptWithDelta(handleListTransactions),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof ListTransactionsSchema>>(),
@@ -374,7 +373,6 @@ Examples:
 Errors:
   - "No default budget set" → run ynab_set_default_budget first`,
 		inputSchema: ExportTransactionsSchema,
-		outputSchema: ExportTransactionsOutputSchema,
 		handler: adapt(handleExportTransactions),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof ExportTransactionsSchema>>(),
@@ -401,7 +399,6 @@ Errors:
   - "No default budget set" → run ynab_set_default_budget first
   - "Transaction not found" → invalid transaction_id`,
 		inputSchema: GetTransactionSchema,
-		outputSchema: GetTransactionOutputSchema,
 		handler: adapt(handleGetTransaction),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof GetTransactionSchema>>(),

--- a/src/tools/transactionWriteTools.ts
+++ b/src/tools/transactionWriteTools.ts
@@ -2044,7 +2044,6 @@ Returns: created transaction with account_balance.
 Examples:
   - $50 expense: set amount=-50000 (milliunits)`,
 		inputSchema: CreateTransactionSchema,
-		outputSchema: CreateTransactionOutputSchema,
 		handler: adaptWrite(handleCreateTransaction),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof CreateTransactionSchema>>(),
@@ -2071,7 +2070,6 @@ Examples:
   - Dry run first: set dry_run=true to validate before committing
   - Avoid duplicate import: set import_id on each transaction`,
 		inputSchema: CreateTransactionsSchema,
-		outputSchema: CreateTransactionsOutputSchema,
 		handler: adaptWrite(handleCreateTransactions),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof CreateTransactionsSchema>>(),
@@ -2099,7 +2097,6 @@ Args:
 
 Returns: transaction with subtransactions and receipt_summary.`,
 		inputSchema: CreateReceiptSplitTransactionSchema,
-		outputSchema: CreateReceiptSplitTransactionOutputSchema,
 		handler: adaptWrite(handleCreateReceiptSplitTransaction),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof CreateReceiptSplitTransactionSchema>>(),
@@ -2129,7 +2126,6 @@ Args:
 
 Returns: updated transaction with updated_balance.`,
 		inputSchema: UpdateTransactionSchema,
-		outputSchema: UpdateTransactionOutputSchema,
 		handler: adaptWrite(handleUpdateTransaction),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof UpdateTransactionSchema>>(),
@@ -2155,7 +2151,6 @@ Returns: summary (updated, failed), results[], transactions[].
 Examples:
   - Dry run: set dry_run=true to preview before/after for first 10 items`,
 		inputSchema: UpdateTransactionsSchema,
-		outputSchema: UpdateTransactionsOutputSchema,
 		handler: adaptWrite(handleUpdateTransactions),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof UpdateTransactionsSchema>>(),
@@ -2181,7 +2176,6 @@ Returns: deleted transaction id and updated account balance.
 Errors:
   - "Transaction not found" → invalid transaction_id`,
 		inputSchema: DeleteTransactionSchema,
-		outputSchema: DeleteTransactionOutputSchema,
 		handler: adaptWrite(handleDeleteTransaction),
 		defaultArgumentResolver:
 			budgetResolver<z.infer<typeof DeleteTransactionSchema>>(),

--- a/src/tools/utilityTools.ts
+++ b/src/tools/utilityTools.ts
@@ -85,7 +85,6 @@ Returns: user (id)
 Errors:
   - "UNAUTHORIZED" → YNAB token expired or invalid`,
 		inputSchema: GetUserSchema,
-		outputSchema: GetUserOutputSchema,
 		handler: adapt(handleGetUser),
 		metadata: {
 			annotations: {


### PR DESCRIPTION
## Summary

Removes `outputSchema` declarations from all 22 tool registrations to fix compatibility with MCP SDK 1.27+ clients.

Fixes #13

## Problem

The MCP specification requires that tools declaring `outputSchema` must return `structuredContent` in every response. The MCP SDK 1.27.0+ enforces this in its Client class, throwing `RuntimeError: Tool has an output schema but did not return structured content`.

Since ynab-mcpb returns markdown-formatted text by default, `toolRegistry.validateOutput()` can't parse it as JSON, so no `structuredContent` is set — violating the outputSchema contract.

## Fix

Remove `outputSchema` from all tool registrations (22 lines across 8 files). The tools continue to work identically — they just no longer claim to return structured output when they actually return markdown.

## Files Changed

- `src/tools/budgetTools.ts` — 2 tools
- `src/tools/accountTools.ts` — 3 tools  
- `src/tools/categoryTools.ts` — 3 tools
- `src/tools/monthTools.ts` — 2 tools
- `src/tools/payeeTools.ts` — 2 tools
- `src/tools/transactionReadTools.ts` — 3 tools
- `src/tools/transactionWriteTools.ts` — 6 tools
- `src/tools/utilityTools.ts` — 1 tool

## Testing

Confirmed working with MCP SDK 1.27.0 via LiteLLM MCP hosting. All 28 tools load and execute correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the configuration setup of multiple YNAB integration tools including accounts, budgets, categories, transactions, payees, and user functions. Tool capabilities and performance remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->