### PR TITLE
chore: update dependencies and target Node 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Profiles are selected once at server startup, so clients receive a stable `tools
 
 | Symptom | Fix |
 |---|---|
-| `npx` fails | Install Node.js 20+, then restart your MCP client. |
+| `npx` fails | Install Node.js 24+, then restart your MCP client. |
 | Auth errors | Regenerate your YNAB token and update `YNAB_ACCESS_TOKEN`. |
 | Tools not detected | Restart the MCP client after any config change. |
 | Reconciliation issues | [Open an issue](https://github.com/dizzlkheinz/ynab-mcpb/issues) with an anonymized CSV sample. |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Download MCPB](https://img.shields.io/badge/Download-MCPB-2563EB?style=for-the-badge&logo=github&logoColor=white)](https://github.com/dizzlkheinz/ynab-mcpb/releases/latest)
 [![npm](https://img.shields.io/npm/v/@dizzlkheinz/ynab-mcpb.svg?style=for-the-badge&logo=npm&logoColor=white)](https://www.npmjs.com/package/@dizzlkheinz/ynab-mcpb)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue?style=for-the-badge)](LICENSE)
-[![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933?style=for-the-badge&logo=node.js&logoColor=white)](https://nodejs.org)
+[![Node.js](https://img.shields.io/badge/Node.js-24%2B-339933?style=for-the-badge&logo=node.js&logoColor=white)](https://nodejs.org)
 
 </div>
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
 	"files": {
 		"includes": [
 			"**",
@@ -7,6 +7,7 @@
 			"!**/coverage",
 			"!**/node_modules",
 			"!**/.git",
+			"!**/.claude",
 			"!**/test-results",
 			"!**/test-results.json",
 			"!**/graphify-out"

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
 	],
 	"compatibility": {
 		"platforms": ["darwin", "win32", "linux"],
-		"runtimes": { "node": ">=20.0.0" }
+		"runtimes": { "node": ">=24.0.0" }
 	},
 	"tools": [
 		{ "name": "ynab_list_budgets", "description": "List YNAB budgets." },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,9 @@
 			"name": "@dizzlkheinz/ynab-mcpb",
 			"version": "0.27.1",
 			"license": "AGPL-3.0",
-			"engines": {
-				"node": ">=20.0.0"
-			},
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.29.0",
-				"chrono-node": "^2.9.1",
+				"@modelcontextprotocol/sdk": "^1.30.0",
+				"chrono-node": "^2.10.1",
 				"csv-parse": "^7.0.1",
 				"date-fns": "^4.4.0",
 				"dotenv": "^17.4.2",
@@ -27,16 +24,19 @@
 				"ynab-mcp-server": "bin/ynab-mcp-server.cjs"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.5.3",
-				"@types/node": "^26.1.1",
+				"@biomejs/biome": "^2.5.6",
+				"@types/node": "^24.13.3",
 				"@types/papaparse": "^5.5.2",
 				"@vitest/coverage-v8": "^4.1.10",
 				"@vitest/ui": "^4.1.10",
 				"esbuild": "^0.28.1",
 				"rimraf": "^6.1.3",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "^7.0.2",
 				"vitest": "^4.1.10"
+			},
+			"engines": {
+				"node": ">=24.0.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
@@ -100,9 +100,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-			"integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
+			"integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -116,20 +116,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.3",
-				"@biomejs/cli-darwin-x64": "2.5.3",
-				"@biomejs/cli-linux-arm64": "2.5.3",
-				"@biomejs/cli-linux-arm64-musl": "2.5.3",
-				"@biomejs/cli-linux-x64": "2.5.3",
-				"@biomejs/cli-linux-x64-musl": "2.5.3",
-				"@biomejs/cli-win32-arm64": "2.5.3",
-				"@biomejs/cli-win32-x64": "2.5.3"
+				"@biomejs/cli-darwin-arm64": "2.5.6",
+				"@biomejs/cli-darwin-x64": "2.5.6",
+				"@biomejs/cli-linux-arm64": "2.5.6",
+				"@biomejs/cli-linux-arm64-musl": "2.5.6",
+				"@biomejs/cli-linux-x64": "2.5.6",
+				"@biomejs/cli-linux-x64-musl": "2.5.6",
+				"@biomejs/cli-win32-arm64": "2.5.6",
+				"@biomejs/cli-win32-x64": "2.5.6"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-			"integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
 			"cpu": [
 				"arm64"
 			],
@@ -144,9 +144,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-			"integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
 			"cpu": [
 				"x64"
 			],
@@ -161,9 +161,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-			"integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
+			"integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
 			"cpu": [
 				"arm64"
 			],
@@ -181,9 +181,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-			"integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
 			"cpu": [
 				"arm64"
 			],
@@ -201,9 +201,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-			"integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
+			"integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
 			"cpu": [
 				"x64"
 			],
@@ -221,9 +221,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-			"integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
 			"cpu": [
 				"x64"
 			],
@@ -241,9 +241,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-			"integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
 			"cpu": [
 				"arm64"
 			],
@@ -258,9 +258,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-			"integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
 			"cpu": [
 				"x64"
 			],
@@ -751,12 +751,12 @@
 			}
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.14",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+			"integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.14.1"
+				"node": ">=20"
 			},
 			"peerDependencies": {
 				"hono": "^4"
@@ -791,12 +791,12 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.29.0",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+			"integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
 			"license": "MIT",
 			"dependencies": {
-				"@hono/node-server": "^1.19.9",
+				"@hono/node-server": "^1.19.9 || ^2.0.5",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"content-type": "^1.0.5",
@@ -1192,13 +1192,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "26.1.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+			"version": "24.13.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+			"integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~8.3.0"
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/@types/papaparse": {
@@ -1796,20 +1796,20 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"debug": "^4.4.3",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.7.0",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.1",
-				"raw-body": "^3.0.1",
-				"type-is": "^2.0.1"
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1819,17 +1819,30 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/bytes": {
@@ -1881,9 +1894,9 @@
 			}
 		},
 		"node_modules/chrono-node": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.9.1.tgz",
-			"integrity": "sha512-nqP8Zp11efCYQIESXPxeDM8ikzN5BDb3Zzou+a66fZq+X2hzKFdsNLQE2/uBAh//BZEMbaMo1eTnagK7hOenAg==",
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.10.1.tgz",
+			"integrity": "sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g==",
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -2263,9 +2276,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"funding": [
 				{
 					"type": "github",
@@ -3080,9 +3093,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3278,9 +3291,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+			"integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3298,7 +3311,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -3752,9 +3765,9 @@
 			"optional": true
 		},
 		"node_modules/tsx": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-			"integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3837,9 +3850,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
 	"author": "dizzlkheinz",
 	"license": "AGPL-3.0",
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=24.0.0"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.29.0",
-		"chrono-node": "^2.9.1",
+		"@modelcontextprotocol/sdk": "^1.30.0",
+		"chrono-node": "^2.10.1",
 		"csv-parse": "^7.0.1",
 		"date-fns": "^4.4.0",
 		"dotenv": "^17.4.2",
@@ -88,14 +88,14 @@
 		"zod-validation-error": "^5.0.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.3",
-		"@types/node": "^26.1.1",
+		"@biomejs/biome": "^2.5.6",
+		"@types/node": "^24.13.3",
 		"@types/papaparse": "^5.5.2",
 		"@vitest/coverage-v8": "^4.1.10",
 		"@vitest/ui": "^4.1.10",
 		"esbuild": "^0.28.1",
 		"rimraf": "^6.1.3",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^7.0.2",
 		"vitest": "^4.1.10"
 	},

--- a/src/server/__tests__/YNABMCPServer.unit.test.ts
+++ b/src/server/__tests__/YNABMCPServer.unit.test.ts
@@ -92,10 +92,13 @@ describe("YNABMCPServer isolated behavior", () => {
 		[new Error("network unavailable"), "network unavailable"],
 		[new Error(""), "Token validation failed"],
 		[42, "Token validation failed: 42"],
-	] as const)("classifies token validation failure %#", async (error, message) => {
-		vi.spyOn(server.getYNABAPI().user, "getUser").mockRejectedValue(error);
-		await expect(server.validateToken()).rejects.toThrow(message);
-	});
+	] as const)(
+		"classifies token validation failure %#",
+		async (error, message) => {
+			vi.spyOn(server.getYNABAPI().user, "getUser").mockRejectedValue(error);
+			await expect(server.validateToken()).rejects.toThrow(message);
+		},
+	);
 
 	it("returns true for a valid token", async () => {
 		vi.spyOn(server.getYNABAPI().user, "getUser").mockResolvedValue({

--- a/src/server/__tests__/errorHandler.branches.test.ts
+++ b/src/server/__tests__/errorHandler.branches.test.ts
@@ -49,13 +49,16 @@ describe("ErrorHandler high-risk branches", () => {
 		["transaction lookup", "transaction"],
 		["payee lookup", "payee"],
 		["resource lookup", "find"],
-	] as const)("uses a contextual not-found response for %s", (context, expected) => {
-		const parsed = parse(
-			new YNABAPIError(YNABErrorCode.NOT_FOUND, "missing"),
-			context,
-		);
-		expect(parsed.error.userMessage.toLowerCase()).toContain(expected);
-	});
+	] as const)(
+		"uses a contextual not-found response for %s",
+		(context, expected) => {
+			const parsed = parse(
+				new YNABAPIError(YNABErrorCode.NOT_FOUND, "missing"),
+				context,
+			);
+			expect(parsed.error.userMessage.toLowerCase()).toContain(expected);
+		},
+	);
 
 	it.each([
 		"listing accounts",
@@ -96,13 +99,16 @@ describe("ErrorHandler high-risk branches", () => {
 		[{ status: 418 }, "UNKNOWN_ERROR"],
 		[{ status: 0 }, "UNKNOWN_ERROR"],
 		[{ status: "401" }, "UNKNOWN_ERROR"],
-	] as const)("extracts supported HTTP status shapes", (error, expectedCode) => {
-		const parsed = parse(error, "requesting data");
-		expect(parsed.error.code).toBe(expectedCode);
-		if (parsed.error.details) {
-			expect(parsed.error.details).not.toContain("secret");
-		}
-	});
+	] as const)(
+		"extracts supported HTTP status shapes",
+		(error, expectedCode) => {
+			const parsed = parse(error, "requesting data");
+			expect(parsed.error.code).toBe(expectedCode);
+			if (parsed.error.details) {
+				expect(parsed.error.details).not.toContain("secret");
+			}
+		},
+	);
 
 	it.each([
 		[{ error: { id: "401", detail: "token=secret" } }, 401],

--- a/src/server/__tests__/toolRegistration.test.ts
+++ b/src/server/__tests__/toolRegistration.test.ts
@@ -108,17 +108,20 @@ describe("Tool Registration", () => {
 			["reconciliation", EXPECTED_TOOLS_BY_DOMAIN.reconciliation],
 			["utility", EXPECTED_TOOLS_BY_DOMAIN.utility],
 			["server", EXPECTED_TOOLS_BY_DOMAIN.server],
-		])("registers all %s domain tools", (domain: string, expectedTools: readonly string[]) => {
-			const server = new YNABMCPServer(false);
-			const tools = server.getToolRegistry().listTools();
-			const toolNames = tools.map((t) => t.name);
+		])(
+			"registers all %s domain tools",
+			(domain: string, expectedTools: readonly string[]) => {
+				const server = new YNABMCPServer(false);
+				const tools = server.getToolRegistry().listTools();
+				const toolNames = tools.map((t) => t.name);
 
-			for (const toolName of expectedTools) {
-				expect(toolNames, `Missing ${domain} tool: ${toolName}`).toContain(
-					toolName,
-				);
-			}
-		});
+				for (const toolName of expectedTools) {
+					expect(toolNames, `Missing ${domain} tool: ${toolName}`).toContain(
+						toolName,
+					);
+				}
+			},
+		);
 	});
 
 	describe("Tool Metadata Verification", () => {

--- a/src/server/__tests__/writeSafety.test.ts
+++ b/src/server/__tests__/writeSafety.test.ts
@@ -248,25 +248,25 @@ describe("ToolRegistry write safety enforcement", () => {
 		expect(handler).toHaveBeenCalledTimes(1);
 	});
 
-	it.each([
-		"ynab_create_transactions",
-		"ynab_delete_transaction",
-	])("forces dry-run preview for protected bulk/deletion tool %s", async (name) => {
-		const registry = new ToolRegistry(
-			createDependencies(new WriteSafetyPolicy({ mode: "preview" })),
-		);
-		const handler = registerMutation(registry, name);
-		await registry.executeTool({
-			name,
-			accessToken: "token",
-			arguments: { id: "target" },
-		});
-		expect(handler).toHaveBeenCalledWith(
-			expect.objectContaining({
-				input: expect.objectContaining({ dry_run: true }),
-			}),
-		);
-	});
+	it.each(["ynab_create_transactions", "ynab_delete_transaction"])(
+		"forces dry-run preview for protected bulk/deletion tool %s",
+		async (name) => {
+			const registry = new ToolRegistry(
+				createDependencies(new WriteSafetyPolicy({ mode: "preview" })),
+			);
+			const handler = registerMutation(registry, name);
+			await registry.executeTool({
+				name,
+				accessToken: "token",
+				arguments: { id: "target" },
+			});
+			expect(handler).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({ dry_run: true }),
+				}),
+			);
+		},
+	);
 
 	it("rejects protected registrations that cannot preview", () => {
 		const registry = new ToolRegistry(

--- a/src/tools/reconciliation/__tests__/executorErrors.test.ts
+++ b/src/tools/reconciliation/__tests__/executorErrors.test.ts
@@ -64,11 +64,12 @@ describe("reconciliation executor error normalization", () => {
 		});
 	});
 
-	it.each([
-		400, 401, 403, 404, 429, 500, 503,
-	])("propagates fatal HTTP status %s", (status) => {
-		expect(shouldPropagateYnabError({ status, message: "fatal" })).toBe(true);
-	});
+	it.each([400, 401, 403, 404, 429, 500, 503])(
+		"propagates fatal HTTP status %s",
+		(status) => {
+			expect(shouldPropagateYnabError({ status, message: "fatal" })).toBe(true);
+		},
+	);
 
 	it("does not propagate nonfatal or absent statuses", () => {
 		expect(shouldPropagateYnabError({ status: 409, message: "conflict" })).toBe(

--- a/src/utils/__tests__/amountUtils.test.ts
+++ b/src/utils/__tests__/amountUtils.test.ts
@@ -12,13 +12,12 @@ describe("amountUtils", () => {
 		expect(milliunitsToAmount(1234.6)).toBe(1.235);
 	});
 
-	it.each([
-		Number.NaN,
-		Number.POSITIVE_INFINITY,
-		Number.NEGATIVE_INFINITY,
-	])("rejects non-finite amount %s", (amount) => {
-		expect(() => amountToMilliunits(amount)).toThrow("not a finite number");
-	});
+	it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+		"rejects non-finite amount %s",
+		(amount) => {
+			expect(() => amountToMilliunits(amount)).toThrow("not a finite number");
+		},
+	);
 
 	it("formats with default and explicit currency symbols", () => {
 		expect(formatAmount(1234)).toBe("$1.23");


### PR DESCRIPTION
## Summary

- update all outdated direct dependencies and remediate vulnerable transitive dependencies
- raise the supported runtime floor to Node.js 24 and align `@types/node`
- synchronize MCPB manifest and README runtime metadata
- update Biome and apply its mechanical formatting changes

## Why

Node.js 20 is end-of-life, the project already builds and releases on Node.js 24, and the prior dependency lock contained six npm advisories. This aligns the declared runtime with CI and removes the vulnerable dependency versions.

## Impact

Consumers now need Node.js 24 or newer. The dependency tree has zero known npm audit vulnerabilities.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run verify:metadata`
- `npm test` — 1,787 passed, 13 skipped
- `npm run type-check`
- production TypeScript compilation
- non-live integration suite — 67 passed
- unit suite under Node.js 24.18.0 — 1,787 passed
- `npm audit` — zero vulnerabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented minimum Node.js version from 20 to 24.

* **Compatibility**
  * Raised the required Node.js runtime version to 24 or later.

* **Maintenance**
  * Updated application and development tooling dependencies.
  * Refined linting and formatting configuration.

* **Tests**
  * Improved test formatting and consistency without changing test coverage or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->